### PR TITLE
AOT compatibility

### DIFF
--- a/lib/checkbox-editor/checkbox-editor.component.ts
+++ b/lib/checkbox-editor/checkbox-editor.component.ts
@@ -54,13 +54,13 @@ export class CheckBoxEditorComponent implements ControlValueAccessor, OnInit {
     @Output() onCancel: EventEmitter<string> = new EventEmitter();
     @Output() onEditing: EventEmitter<string> = new EventEmitter();
 
-    private _originalValue: any;
-    display: string = '';
-    private _value: true; // Private variable for input value
-    private preValue: string = ''; // The value before clicking to edit
-    private editing: boolean = false; // Is Component in edit mode?
+    public display: string = '';
+    public preValue: string = ''; // The value before clicking to edit
+    public editing: boolean = false; // Is Component in edit mode?
     public onChange: any = Function.prototype; // Trascend the onChange event
     public onTouched: any = Function.prototype; // Trascend the onTouch event
+    private _originalValue: any;
+    private _value: true; // Private variable for input value
 
     constructor(element: ElementRef, private _renderer: Renderer) { }
 

--- a/lib/checklist-editor/checklist-editor.component.ts
+++ b/lib/checklist-editor/checklist-editor.component.ts
@@ -70,13 +70,13 @@ export class CheckListEditorComponent implements ControlValueAccessor, OnInit {
   @Output() onCancel: EventEmitter<string> = new EventEmitter();
   @Output() onEditing: EventEmitter<string> = new EventEmitter();
 
-  private _originalValue: any;
-  private _value: any[] = []; // Private variable for input value
-  private preValue: string = ''; // The value before clicking to edit
-  private editing: boolean = false; // Is Component in edit mode?
+  public editing: boolean = false; // Is Component in edit mode?
+  public preValue: string = ''; // The value before clicking to edit
   public onChange: any = Function.prototype; // Trascend the onChange event
   public onTouched: any = Function.prototype; // Trascend the onTouch event
-  private checklistReqflag: boolean = false;
+  public checklistReqflag: boolean = false;
+  private _originalValue: any;
+  private _value: any[] = []; // Private variable for input value
 
   constructor(element: ElementRef, private _renderer: Renderer) { }
 

--- a/lib/date-editor/date-editor.component.ts
+++ b/lib/date-editor/date-editor.component.ts
@@ -61,13 +61,13 @@ export class DateEditorComponent implements ControlValueAccessor, OnInit {
   @Output() onCancel: EventEmitter<string> = new EventEmitter();
   @Output() onEditing: EventEmitter<string> = new EventEmitter();
 
-  private _originalValue: any;
-  private _value: string = ''; // Private variable for input value
-  private preValue: string = ''; // The value before clicking to edit
-  private editing: boolean = false; // Is Component in edit mode?
+  public preValue: string = ''; // The value before clicking to edit
+  public editing: boolean = false; // Is Component in edit mode?
   public onChange: any = Function.prototype; // Trascend the onChange event
   public onTouched: any = Function.prototype; // Trascend the onTouch event
-  private dateReqflag: boolean = false;
+  public dateReqflag: boolean = false;
+  private _originalValue: any;
+  private _value: string = ''; // Private variable for input value
 
   constructor(element: ElementRef, private _renderer: Renderer) { }
 

--- a/lib/datetimepicker-editor/datetimepicker-editor.component.ts
+++ b/lib/datetimepicker-editor/datetimepicker-editor.component.ts
@@ -72,15 +72,15 @@ export class DateTimeEditorComponent implements ControlValueAccessor, OnInit {
   @Output() onCancel: EventEmitter<string> = new EventEmitter();
   @Output() onEditing: EventEmitter<string> = new EventEmitter();
 
-  private _originalValue: any;
-  private _value: Date; // Private variable for input value
-  private preValue: string = ''; // The value before clicking to edit
-  private editing: boolean = false; // Is Component in edit mode?
+  public preValue: string = ''; // The value before clicking to edit
+  public editing: boolean = false; // Is Component in edit mode?
   public onChange: any = Function.prototype; // Trascend the onChange event
   public onTouched: any = Function.prototype; // Trascend the onTouch event
-  private dateReqflag: boolean = false;
-  private selectedTime:Date;
-  private selectedDateTime:boolean=false;
+  public dateReqflag: boolean = false;
+  public selectedTime: Date;
+  public selectedDateTime: boolean = false;
+  private _originalValue: any;
+  private _value: Date; // Private variable for input value
 
   showTimePicker:boolean =false;
 

--- a/lib/input-editor/input-editor.component.ts
+++ b/lib/input-editor/input-editor.component.ts
@@ -58,15 +58,14 @@ export class InputEditorComponent implements ControlValueAccessor, OnInit {
   @Output() onSave: EventEmitter<string> = new EventEmitter();
   @Output() onCancel: EventEmitter<string> = new EventEmitter();
   @Output() onEditing: EventEmitter<string> = new EventEmitter();
-  
 
-  private _originalValue:any;
-  private _value: string = ''; // Private variable for input value
-  private preValue: string = ''; // The value before clicking to edit
-  private editing: boolean = false; // Is Component in edit mode?
+  public editing: boolean = false; // Is Component in edit mode?
+  public preValue: string = ''; // The value before clicking to edit
+  public inputReqflag:boolean = false;
   public onChange: any = Function.prototype; // Trascend the onChange event
   public onTouched: any = Function.prototype; // Trascend the onTouch event
-  private inputReqflag:boolean = false;
+  private _originalValue:any;
+  private _value: string = ''; // Private variable for input value
 
   constructor(element: ElementRef, private _renderer: Renderer) { }
   

--- a/lib/inputnumber-editor/number-editor.component.ts
+++ b/lib/inputnumber-editor/number-editor.component.ts
@@ -70,39 +70,24 @@ export class NumberEditorComponent implements ControlValueAccessor, OnInit {
   @Output() onCancel: EventEmitter<string> = new EventEmitter();
   @Output() onEditing: EventEmitter<string> = new EventEmitter();
 
-  private _originalValue: any;
-  private _value: number; // Private variable for input value
-  private preValue: string = ''; // The value before clicking to edit
-  private editing: boolean = false; // Is Component in edit mode?
+  public preValue: string = ''; // The value before clicking to edit
+  public editing: boolean = false; // Is Component in edit mode?
   public onChange: any = Function.prototype; // Trascend the onChange event
   public onTouched: any = Function.prototype; // Trascend the onTouch event
-  private numberReqflag: boolean = false;
-  private numberBigflag: boolean = false;
+  public numberReqflag: boolean = false;
+  public numberBigflag: boolean = false;
+  private _originalValue: any;
+  private _value: number; // Private variable for input value
 
   constructor(element: ElementRef, private _renderer: Renderer) { }
 
   onSaveInputNumber() {
-    if (this.numberEditorControl.nativeElement.value != "" && (this.numberEditorControl.nativeElement.value > this.maxNumber || this.numberEditorControl.nativeElement.value < this.minNumber)) {
-      this.numberBigflag = true;
-      this.numberReqflag = false;
-      return;
-    }
-    else {
-      this.numberBigflag = false;
-    }
+    const enteredValue = this.numberEditorControl.nativeElement.value;
+    
+    this.numberReqflag = this.required === "true" && !enteredValue;
+    this.numberBigflag = enteredValue && (Number(enteredValue) > this.maxNumber || Number(enteredValue) < this.minNumber);
 
-    if (this.required == "true") {
-      if (this.numberEditorControl.nativeElement.value == null || this.numberEditorControl.nativeElement.value === undefined || this.numberEditorControl.nativeElement.value === "") {
-        this.numberReqflag = true;
-        return;
-      }
-      else {
-        this.numberReqflag = false;
-      }
-    }
-    else {
-      this.numberReqflag = false;
-    }
+    if (this.numberBigflag || this.numberReqflag) return;
 
     this.onSave.emit('clicked save');
     this.editing = false;

--- a/lib/pipes/texthighlight.pipe.d.ts
+++ b/lib/pipes/texthighlight.pipe.d.ts
@@ -1,4 +1,4 @@
 import { PipeTransform } from '@angular/core';
 export declare class HighLightPipe implements PipeTransform {
-    transform(text: string, [search]: string): string;
+    transform(text: string, search: string): string;
 }

--- a/lib/pipes/texthighlight.pipe.ts
+++ b/lib/pipes/texthighlight.pipe.ts
@@ -2,7 +2,7 @@ import {PipeTransform, Pipe, ViewEncapsulation} from '@angular/core';
 
 @Pipe({ name: 'highlight' })
 export class HighLightPipe implements PipeTransform {
-  transform(text: string, [search]:string): string {
+  transform(text: string, search: string): string {
     debugger;
     return search ? text.replace(new RegExp(search, 'i'), `<span class="txt-light">${search}</span>`) : text;
   }

--- a/lib/radiolist-editor/radiolist-editor.component.ts
+++ b/lib/radiolist-editor/radiolist-editor.component.ts
@@ -64,14 +64,14 @@ export class RadioListEditorComponent implements ControlValueAccessor, OnInit {
     @Output() onCancel: EventEmitter<string> = new EventEmitter();
     @Output() onEditing: EventEmitter<string> = new EventEmitter();
 
+    public editing: boolean = false; // Is Component in edit mode?
+    public preValue: string = ''; // The value before clicking to edit
+    public radiolistReqflag: boolean = false;
     public isEmpty: boolean = true;
-    private _originalValue: any;
-    private _value: any[] = []; // Private variable for input value
-    private preValue: string = ''; // The value before clicking to edit
-    private editing: boolean = false; // Is Component in edit mode?
     public onChange: any = Function.prototype; // Trascend the onChange event
     public onTouched: any = Function.prototype; // Trascend the onTouch event
-    private radiolistReqflag: boolean = false;
+    private _originalValue: any;
+    private _value: any[] = []; // Private variable for input value
 
     constructor(element: ElementRef, private _renderer: Renderer) { }
 

--- a/lib/select-editor/select-editor.component.ts
+++ b/lib/select-editor/select-editor.component.ts
@@ -65,14 +65,14 @@ export class SelectEditorComponent implements ControlValueAccessor, OnInit {
   @Output() clickoutside = new EventEmitter<MouseEvent>();
   @Output() onEditing: EventEmitter<string> = new EventEmitter();
 
-  private _value: any = ''; // Private variable for input value
-  private preValue: string = ''; // The value before clicking to edit
-  private editing: boolean = false; // Is Component in edit mode?
+  public editing: boolean = false; // Is Component in edit mode?
+  public preValue: string = ''; // The value before clicking to edit
   public onChange: any = Function.prototype; // Trascend the onChange event
   public onTouched: any = Function.prototype; // Trascend the onTouch event
-  private _originalValue:any;
-  private open:boolean=false;
-  private selectReqflag:boolean=false;
+  public selectReqflag: boolean = false;
+  private _value: any = ''; // Private variable for input value
+  private _originalValue: any;
+  private open: boolean = false;
   
   constructor(private _elementRef: ElementRef, private _renderer: Renderer) { }
 

--- a/lib/tags-editor/tags-editor.component.ts
+++ b/lib/tags-editor/tags-editor.component.ts
@@ -78,17 +78,15 @@ export class TagsEditorComponent implements ControlValueAccessor, OnInit {
   @Output() onCancel: EventEmitter<string> = new EventEmitter();
   @Output() onEditing: EventEmitter<string> = new EventEmitter();
 
-  tags:string[]=[];
-  private _originalValue:any;
-  private _value: string[] = []; // Private variable for input value
-  private preValue: string[] = []; // The value before clicking to edit
-  private editing: boolean = false; // Is Component in edit mode?
+  public tags: string[] = [];
+  public preValue: string[] = []; // The value before clicking to edit
+  public editing: boolean = false; // Is Component in edit mode?
   public onChange: any = Function.prototype; // Trascend the onChange event
   public onTouched: any = Function.prototype; // Trascend the onTouch event
-  isempty:boolean;
-  private tagsReqflag:boolean = false;
-
-
+  public isempty: boolean;
+  public tagsReqflag:boolean = false;
+  private _originalValue:any;
+  private _value: string[] = []; // Private variable for input value
 
   constructor(element: ElementRef, private _renderer: Renderer) { }
 

--- a/lib/textarea-editor/textarea-editor.component.ts
+++ b/lib/textarea-editor/textarea-editor.component.ts
@@ -60,13 +60,13 @@ export class TextAreaEditorComponent implements ControlValueAccessor, OnInit {
     @Output() onCancel: EventEmitter<string> = new EventEmitter();
     @Output() onEditing: EventEmitter<string> = new EventEmitter();
 
-    private _originalValue: any;
-    private _value: string = ''; // Private variable for input value
-    private preValue: string = ''; // The value before clicking to edit
-    private editing: boolean = false; // Is Component in edit mode?
+    public editing: boolean = false; // Is Component in edit mode?
+    public preValue: string = ''; // The value before clicking to edit
     public onChange: any = Function.prototype; // Trascend the onChange event
     public onTouched: any = Function.prototype; // Trascend the onTouch event
-    private textareaReqflag: boolean = false;
+    public textareaReqflag: boolean = false;
+    private _originalValue: any;
+    private _value: string = ''; // Private variable for input value
 
     constructor(element: ElementRef, private _renderer: Renderer) { }
 

--- a/lib/time-editor/time-editor.component.ts
+++ b/lib/time-editor/time-editor.component.ts
@@ -74,14 +74,14 @@ export class TimeEditorComponent implements ControlValueAccessor, OnInit {
   @Output() onCancel: EventEmitter<string> = new EventEmitter();
   @Output() onEditing: EventEmitter<string> = new EventEmitter();
 
-  private _originalValue: any;
-  private _value: any; // Private variable for input value
-  private preValue: string = ''; // The value before clicking to edit
-  private editing: boolean = false; // Is Component in edit mode?
+  public preValue: string = ''; // The value before clicking to edit
+  public editing: boolean = false; // Is Component in edit mode?
   public onChange: any = Function.prototype; // Trascend the onChange event
   public onTouched: any = Function.prototype; // Trascend the onTouch event
-  private timeReqflag: boolean = false;
-  private showTimePicker: boolean = false;
+  public timeReqflag: boolean = false;
+  public showTimePicker: boolean = false;
+  private _originalValue: any;
+  private _value: any; // Private variable for input value
 
   constructor(element: ElementRef, private _renderer: Renderer) { }
 

--- a/lib/typeahead-editor/typeahead-editor.component.ts
+++ b/lib/typeahead-editor/typeahead-editor.component.ts
@@ -71,18 +71,18 @@ export class TypeAheadEditorComponent implements ControlValueAccessor, OnInit {
   @Output() onEditing: EventEmitter<string> = new EventEmitter();
 
   public open: boolean = false;
-  private displayText: string;
-  private _originalValue: any;
+  public displayText: string;
   public filterArg: any;
-  private _value: string = ''; // Private variable for input value
-  private preValue: string = ''; // The value before clicking to edit
-  private editing: boolean = false; // Is Component in edit mode?
+  public preValue: string = ''; // The value before clicking to edit
+  public editing: boolean = false; // Is Component in edit mode?
   public onChange: any = Function.prototype; // Trascend the onChange event
   public onTouched: any = Function.prototype; // Trascend the onTouch event
-  private typeaheadReqflag: boolean = false;
-  private scrolledIndex: number = -1;
-  private availOptions: any[] = [];
-  private aheadKey: string;
+  public typeaheadReqflag: boolean = false;
+  public scrolledIndex: number = -1;
+  public availOptions: any[] = [];
+  public aheadKey: string;
+  private _originalValue: any;
+  private _value: string = ''; // Private variable for input value
 
   constructor(element: ElementRef, private _renderer: Renderer) { }
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/codechavez/angular-inline-editor.git"
   },
   "scripts": {
-    "compile": "tsc --rootDir lib --outDir dist",
+    "compile": "ngc -p tsconfig.json --rootdir lib --outdir dist",
     "html": "XCOPY /S /y .\\lib\\*.html .\\dist",
     "css": "XCOPY /S /y .\\lib\\*.css .\\dist",
     "serve": "webpack-dev-server --host localhost --port 3030 --inline --progress",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,9 +11,17 @@
         "declaration": true,
         "types": ["node"],
         "suppressImplicitAnyIndexErrors": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
     },
     "exclude": [
-        "demo/**/*"
-    ]
+        "demo/**/*",
+        "dist"
+    ],
+    "angularCompilerOptions": {
+      "genDir": "dist",
+      "debug": false,
+      "skipTemplateCodegen": true,
+      "skipMetadataEmit": false,
+      "strictMetadataEmit": true
+    }
 }


### PR DESCRIPTION
Adding AOT compatibility. For users that got errors related to function calls occurring in decorators, this was due to the inline editor module decorator being compiled as a function, preventing the module from being usable in AOT. Resolved by using the Angular compiler to do the library compilation instead of tsc. Additionally, there were other issues that needed to be resolved for AOT compatibility, specifically a lot of variables needed to be made public to be accessible to the template. FWIW, the library can be compiled and used just using the compile script, since html and css get packed in.

Lastly, there was a minor fix for the number editor. (It was broken in the demo due to using string comparison instead of numeric comparison.)

fixes #1 
fixes #3 
